### PR TITLE
deployable hub controller PropagatedStatus update issues

### DIFF
--- a/pkg/controller/deployable/deployable_controller.go
+++ b/pkg/controller/deployable/deployable_controller.go
@@ -321,10 +321,7 @@ func (r *ReconcileDeployable) Reconcile(request reconcile.Request) (reconcile.Re
 	newPropagatedStatus := make(map[string]*appv1alpha1.ResourceUnitStatus)
 
 	for k, v := range instance.Status.PropagatedStatus {
-		newResourceUnitStatus := &appv1alpha1.ResourceUnitStatus{}
-		newResourceUnitStatus = v
-
-		newPropagatedStatus[k] = newResourceUnitStatus
+		newPropagatedStatus[k] = v
 	}
 
 	// only update hub deployable. no need to update propagated deployable.

--- a/pkg/controller/deployable/deployable_controller.go
+++ b/pkg/controller/deployable/deployable_controller.go
@@ -77,7 +77,7 @@ func (mapper *placementruleMapper) Map(obj handler.MapObject) []reconcile.Reques
 	}
 
 	cname := obj.Meta.GetName()
-	klog.V(10).Info("In placement Mapper:", cname)
+	klog.V(5).Info("In placement Mapper:", cname)
 
 	var requests []reconcile.Request
 
@@ -120,7 +120,7 @@ func (mapper *clusterMapper) Map(obj handler.MapObject) []reconcile.Request {
 	}
 
 	cname := obj.Meta.GetName()
-	klog.V(10).Info("In cluster Mapper for ", cname)
+	klog.V(5).Info("In cluster Mapper for ", cname)
 
 	var requests []reconcile.Request
 
@@ -270,7 +270,7 @@ func (mapper *deployableMapper) Map(obj handler.MapObject) []reconcile.Request {
 		requests = append(requests, reconcile.Request{NamespacedName: *hdplkey})
 	}
 
-	klog.V(10).Info("Out deployable mapper with requests:", requests)
+	klog.V(5).Info("Out deployable mapper with requests:", requests)
 
 	return requests
 }
@@ -303,12 +303,12 @@ func (r *ReconcileDeployable) Reconcile(request reconcile.Request) (reconcile.Re
 			// validate all deployables, remove the deployables whose hosting deployables are gone
 			err = r.validateDeployables()
 
-			klog.V(10).Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
+			klog.Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
 
 			return reconcile.Result{}, err
 		}
 		// Error reading the object - requeue the request.
-		klog.V(10).Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
+		klog.Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
 
 		return reconcile.Result{}, err
 	}
@@ -316,38 +316,62 @@ func (r *ReconcileDeployable) Reconcile(request reconcile.Request) (reconcile.Re
 	savedStatus := instance.Status.DeepCopy()
 
 	// try if it is a hub deployable
-	err = r.handleDeployable(instance)
-	if err != nil {
-		instance.Status.Phase = appv1alpha1.DeployableFailed
-		instance.Status.PropagatedStatus = nil
-		instance.Status.Reason = err.Error()
-	} else {
-		instance.Status.Reason = ""
-		instance.Status.Message = ""
+	huberr := r.handleDeployable(instance)
+
+	newPropagatedStatus := make(map[string]*appv1alpha1.ResourceUnitStatus)
+
+	for k, v := range instance.Status.PropagatedStatus {
+		newResourceUnitStatus := &appv1alpha1.ResourceUnitStatus{}
+		newResourceUnitStatus = v
+
+		newPropagatedStatus[k] = newResourceUnitStatus
 	}
 
-	err = r.Update(context.TODO(), instance)
-	if err != nil {
-		klog.Error("Error returned when updating instance:", err, "instance:", instance)
-		return reconcile.Result{}, err
-	}
+	// only update hub deployable. no need to update propagated deployable.
+	if instance.Spec.Placement != nil {
+		err = r.Update(context.TODO(), instance)
 
-	// reconcile finished check if need to upadte the resource
-	if len(instance.GetObjectMeta().GetFinalizers()) == 0 {
-		if !reflect.DeepEqual(savedStatus, &(instance.Status)) {
-			now := metav1.Now()
-			instance.Status.LastUpdateTime = &now
-			klog.V(10).Info("Update status", instance.Status)
-			err = r.Status().Update(context.TODO(), instance)
+		if err != nil {
+			klog.Error("Error returned when updating instance:", err, "instance:", instance)
+			return reconcile.Result{}, err
+		}
 
-			if err != nil {
-				klog.Error("Error returned when updating status:", err, "instance:", instance)
-				return reconcile.Result{}, err
+		// reconcile finished check if need to upadte the resource
+		if len(instance.GetObjectMeta().GetFinalizers()) == 0 {
+			if !reflect.DeepEqual(savedStatus, &(instance.Status)) ||
+				!reflect.DeepEqual(savedStatus.PropagatedStatus, newPropagatedStatus) {
+				now := metav1.Now()
+				instance.Status.LastUpdateTime = &now
+
+				instance.Status.PropagatedStatus = newPropagatedStatus
+
+				if huberr != nil {
+					instance.Status.Phase = appv1alpha1.DeployableFailed
+					instance.Status.PropagatedStatus = nil
+					instance.Status.Reason = huberr.Error()
+				} else {
+					instance.Status.Phase = appv1alpha1.DeployablePropagated
+					instance.Status.Reason = ""
+					instance.Status.Message = ""
+				}
+
+				klog.V(5).Infof("instance: %v/%v, Update status: %#v",
+					instance.GetNamespace(), instance.GetName(),
+					instance.Status)
+
+				utils.PrintPropagatedStatus(instance.Status.PropagatedStatus, "New Propagated Status: ")
+
+				err = r.Status().Update(context.TODO(), instance)
+
+				if err != nil {
+					klog.Error("Error returned when updating status:", err, "instance:", instance)
+					return reconcile.Result{}, err
+				}
 			}
 		}
 	}
 
-	klog.V(10).Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
+	klog.Info("Reconciling - finished.", request.NamespacedName, " with Get err:", err)
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/deployable/rollingupdate.go
+++ b/pkg/controller/deployable/rollingupdate.go
@@ -67,7 +67,7 @@ func (r *ReconcileDeployable) rollingUpdate(instance *appv1alpha1.Deployable) er
 	if err != nil {
 		klog.Info("Failed to find rolling update target", annotations[appv1alpha1.AnnotationRollingUpdateTarget])
 
-		return nil
+		return err
 	}
 
 	//it is only triggered in the initial rolling update.

--- a/pkg/controller/deployable/template.go
+++ b/pkg/controller/deployable/template.go
@@ -65,7 +65,7 @@ func (r *ReconcileDeployable) createManagedDeployable(cluster types.NamespacedNa
 
 	namespace := cluster.Namespace
 	// remove active clusters from expiration list
-	klog.V(10).Info("Creating Managed deployable:", instance, " in cluster:", cluster)
+	klog.V(5).Info("Creating Managed deployable:", instance, " in cluster:", cluster)
 
 	// create or update child deployable
 	truekey := types.NamespacedName{Name: instance.GetName() + "-", Namespace: namespace}.String()
@@ -82,7 +82,7 @@ func (r *ReconcileDeployable) createManagedDeployable(cluster types.NamespacedNa
 	ifRecordEvent := false
 
 	if !ok {
-		klog.V(10).Info("Creating new local deployable:", existingdeployable)
+		klog.V(5).Info("Creating new local deployable:", existingdeployable)
 		err = r.Create(context.TODO(), existingdeployable)
 
 		if instance.Status.PropagatedStatus == nil {
@@ -109,7 +109,7 @@ func (r *ReconcileDeployable) createManagedDeployable(cluster types.NamespacedNa
 			instance.Status.PropagatedStatus[cluster.Name] = &appv1alpha1.ResourceUnitStatus{}
 			ifRecordEvent = true
 		} else {
-			klog.V(10).Info("Same existing local deployable, no need to update. instance: ",
+			klog.V(5).Info("Same existing local deployable, no need to update. instance: ",
 				string(original.Spec.Template.Raw), " vs existing: ", string(existingdeployable.Spec.Template.Raw))
 		}
 	}
@@ -120,7 +120,7 @@ func (r *ReconcileDeployable) createManagedDeployable(cluster types.NamespacedNa
 		error1 := r.Get(context.TODO(), hosting, hostDeployable)
 
 		if error1 != nil {
-			klog.V(10).Info("hosting deployable not found, unable to record events to it. ", hosting)
+			klog.V(5).Info("hosting deployable not found, unable to record events to it. ", hosting)
 		} else {
 			dplkey := types.NamespacedName{Name: existingdeployable.GetName(), Namespace: existingdeployable.GetNamespace()}
 			eventObj := ""
@@ -145,7 +145,7 @@ func (r *ReconcileDeployable) createManagedDeployable(cluster types.NamespacedNa
 	}
 
 	// remove it from to be deleted map
-	klog.V(10).Info("Removing ", truekey, " from ", familymap)
+	klog.V(5).Info("Removing ", truekey, " from ", familymap)
 	delete(familymap, truekey)
 
 	return r.createManagedDependencies(cluster, instance, familymap)
@@ -228,7 +228,7 @@ func (r *ReconcileDeployable) setLocalDeployable(cluster *client.ObjectKey, host
 		}
 	}
 
-	klog.V(10).Info("Local deployable:", localdeployable)
+	klog.V(5).Info("Local deployable:", localdeployable)
 
 	return localdeployable
 }

--- a/pkg/utils/deployable.go
+++ b/pkg/utils/deployable.go
@@ -88,10 +88,12 @@ var DeployablePredicateFunc = predicate.Funcs{
 // CompareDeployable compare two deployables and return true if they are equal.
 func CompareDeployable(olddpl *appv1alpha1.Deployable, newdpl *appv1alpha1.Deployable) bool {
 	if !reflect.DeepEqual(newdpl.GetAnnotations(), olddpl.GetAnnotations()) {
+		klog.V(5).Infof("old annotation: %#v, new annotation: %#v", olddpl.GetAnnotations(), newdpl.GetAnnotations())
 		return false
 	}
 
 	if !reflect.DeepEqual(newdpl.GetLabels(), olddpl.GetLabels()) {
+		klog.V(5).Infof("old lael: %#v, new label: %#v", olddpl.GetLabels(), newdpl.GetLabels())
 		return false
 	}
 
@@ -117,6 +119,7 @@ func CompareDeployable(olddpl *appv1alpha1.Deployable, newdpl *appv1alpha1.Deplo
 	}
 
 	if !reflect.DeepEqual(newtmpl, oldtmpl) {
+		klog.V(5).Infof("old template: %#v, new template: %#v", oldtmpl, newtmpl)
 		return false
 	}
 
@@ -124,7 +127,12 @@ func CompareDeployable(olddpl *appv1alpha1.Deployable, newdpl *appv1alpha1.Deplo
 
 	tmpdpl.Spec.Template = newdpl.Spec.Template.DeepCopy()
 
-	return reflect.DeepEqual(tmpdpl.Spec, newdpl.Spec)
+	if !reflect.DeepEqual(tmpdpl.Spec, newdpl.Spec) {
+		klog.V(5).Infof("old spec: %#v, new spec: %#v", tmpdpl.Spec, newdpl.Spec)
+		return false
+	}
+
+	return true
 }
 
 // PrepareInstance prepares the deployable instane for later actions
@@ -384,4 +392,11 @@ func ContainsName(a []types.NamespacedName, x string) bool {
 	}
 
 	return false
+}
+
+// PrintPropagatedStatus output Propagated Status for each cluster
+func PrintPropagatedStatus(r map[string]*appv1alpha1.ResourceUnitStatus, msg string) {
+	for cluster, unitStatus := range r {
+		klog.Infof("%v - cluster: %v, unit status: %#v", msg, cluster, unitStatus)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xilica.ibm.com@Xiangjings-MacBook-Pro.local>

1) root deployable Status.PropagatedStatus update failed. change to get it updated after r.Update() and before r.Status().Update()

2) annotations AnnotationManagedCluster is no long used

3) deployable controller should only update hub deployable. no need to update propagated deployable (instance.Spec.Placement)
